### PR TITLE
合并6.4.2的改动

### DIFF
--- a/ChangeLogs/6.4.2.md
+++ b/ChangeLogs/6.4.2.md
@@ -1,8 +1,10 @@
 # 6.4.2
 1. Obase.Core
-   - 修复SqlServer建表时错误的将字符串类型设置为varchar类型的问题,应为nvarchar.
+   - 增加完整性检查时检查是否所有的关联端实体型主键都有映射.
+   - 增加完整性检查时检查启用了延迟加载的引用元素对应的属性是否为virtual.
 2. Obase.Providers.Sql
    - 增加SqlServer数据源的ushort,uint,ulong类型参数化时转化为有符号数的逻辑.
    - 修复SqlServer数据源的DateTime类型参数化时空值没有转换为DBNull的问题.
+   - 修复SqlServer建表时错误的将字符串类型映射为varchar类型的问题,应为nvarchar.
 3. Obase.Odm.Annotation/Obase.LogicDeletion/Obase.MultiTenant/Obase.Providers.MySql/Obase.Providers.Oracle/Obase.Providers.SqlServer/Obase.Providers.Sqlite/Obase.Providers.PostgreSql
    - 无实质更新,仅更新版本号.

--- a/ChangeLogs/6.4.2.md
+++ b/ChangeLogs/6.4.2.md
@@ -1,0 +1,8 @@
+# 6.4.2
+1. Obase.Core
+   - 修复SqlServer建表时错误的将字符串类型设置为varchar类型的问题,应为nvarchar.
+2. Obase.Providers.Sql
+   - 增加SqlServer数据源的ushort,uint,ulong类型参数化时转化为有符号数的逻辑.
+   - 修复SqlServer数据源的DateTime类型参数化时空值没有转换为DBNull的问题.
+3. Obase.Odm.Annotation/Obase.LogicDeletion/Obase.MultiTenant/Obase.Providers.MySql/Obase.Providers.Oracle/Obase.Providers.SqlServer/Obase.Providers.Sqlite/Obase.Providers.PostgreSql
+   - 无实质更新,仅更新版本号.

--- a/Src/Obase/Directory.Build.props
+++ b/Src/Obase/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- 统一配置包版本 -->
-    <PackageVersion>6.4.1</PackageVersion>
+    <PackageVersion>6.4.2</PackageVersion>
     <!-- 统一配置输出路径 -->
     <OutputPath>../Output/</OutputPath>
     <!-- 统一配置目标框架 -->

--- a/Src/Obase/Obase.Core/Odm/AssociationType.cs
+++ b/Src/Obase/Obase.Core/Odm/AssociationType.cs
@@ -315,6 +315,21 @@ namespace Obase.Core.Odm
 
                     if (isRepeat)
                         message.Add($"关联型{Name}的关联端{end.Name}内有重复的映射.");
+
+                    //检查Mapping的KeyAttr是否在端类型中存在
+                    foreach (var mapping in end.Mappings)
+                        if (end.EntityType.GetAttribute(mapping.KeyAttribute) == null)
+                            message.Add(
+                                $"关联型{Name}的关联端{end.Name}映射{mapping.KeyAttribute}属性无法在端类型{end.EntityType.ClrType}中找到.");
+                    //检查是否所有的KeyAttr都有映射
+                    foreach (var entityTypeKeyAttribute in end.EntityType.KeyAttributes)
+                    {
+                        //获取端类型的标识属性的映射数量 必须为1
+                        var mapCount = end.Mappings.Count(p => p.KeyAttribute == entityTypeKeyAttribute);
+                        if (mapCount != 1)
+                            message.Add(
+                                $"关联型{Name}的关联端{end.Name}的标识属性{entityTypeKeyAttribute}应有且只1个映射,但现在有{mapCount}个映射.");
+                    }
                 }
 
                 //检查设值器和取值器
@@ -325,12 +340,6 @@ namespace Obase.Core.Odm
                 if (end.ValueSetter == null)
                     message.Add(
                         $"{ClrType}的关联端{end.Name}没有设值器.");
-
-                //检查Mapping
-                foreach (var mapping in end.Mappings ?? new List<AssociationEndMapping>())
-                    if (end.EntityType.GetAttribute(mapping.KeyAttribute) == null)
-                        message.Add(
-                            $"关联型{Name}的关联端{end.Name}映射{mapping.KeyAttribute}属性无法在端类型{end.EntityType.ClrType}中找到.");
             }
 
             //检查键属性

--- a/Src/Obase/Obase.Core/Odm/IntegrityCheckFailException.cs
+++ b/Src/Obase/Obase.Core/Odm/IntegrityCheckFailException.cs
@@ -33,6 +33,11 @@ namespace Obase.Core.Odm
         public Dictionary<string, List<string>> ErrorMessageDictionary { get; }
 
         /// <summary>
+        ///     返回异常消息
+        /// </summary>
+        public override string Message => ToString();
+
+        /// <summary>
         ///     异常消息
         /// </summary>
         /// <returns></returns>

--- a/Src/Obase/Obase.Core/Odm/ObjectType.cs
+++ b/Src/Obase/Obase.Core/Odm/ObjectType.cs
@@ -242,6 +242,20 @@ namespace Obase.Core.Odm
                     message.Add($"实体{Name}的属性{attribute.Name}没有取值器.");
             }
 
+            //检查引用元素的延迟加载配置
+            if (ReferenceElements != null)
+            {
+                foreach (var referenceElement in ReferenceElements)
+                {
+                    //检查引用元素的get方法
+                    var getMethod = referenceElement.HostType?.ClrType?.GetProperty(referenceElement.Name)?.GetMethod;
+                    //如果有GetMethod 且 不是虚方法 且 启用了延迟加载 就增加异常消息
+                    if (getMethod != null && !getMethod.IsVirtual && referenceElement.EnableLazyLoading)
+                        message.Add($"对象类型{Name}的引用元素{referenceElement.Name}启用了延迟加载,但没有将其声明为virtual的.");
+                }
+            }
+            
+
             //如果有检查失败消息
             if (message.Any())
             {

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/BoolFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/BoolFieldSetter.cs
@@ -181,6 +181,7 @@ namespace Obase.Providers.Sql.SqlObject
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
+            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
 
             return parameter;
         }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/DateTimeFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/DateTimeFieldSetter.cs
@@ -198,7 +198,8 @@ namespace Obase.Providers.Sql.SqlObject
             //非空 加入参数
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
-            if (sourceType == EDataSource.PostgreSql) parameters.Value = Value;
+            if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
+            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
             return parameter;
         }
     }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/Field.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/Field.cs
@@ -97,7 +97,7 @@ namespace Obase.Providers.Sql.SqlObject
                 case EDataSource.SqlServer:
                 {
                     return Source?.Symbol != null
-                        ? $"{Source.Symbol}.[{_name}]"
+                        ? $"[{Source.Symbol}].[{_name}]"
                         : $"[{_name}]";
                 }
                 case EDataSource.PostgreSql:

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/NumericFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/NumericFieldSetter.cs
@@ -179,6 +179,15 @@ namespace Obase.Providers.Sql.SqlObject
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
+            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
+            //如果是SqlServer ushrot uint ulong需要转换为有符号的类型
+            if (sourceType == EDataSource.SqlServer)
+            {
+                if (valueStr is ushort || valueStr is uint || valueStr is ulong)
+                {
+                    parameters.Value = Convert.ToInt64(valueStr);
+                }
+            }
             return parameter;
         }
     }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/NumericFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/NumericFieldSetter.cs
@@ -182,12 +182,8 @@ namespace Obase.Providers.Sql.SqlObject
             if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
             //如果是SqlServer ushrot uint ulong需要转换为有符号的类型
             if (sourceType == EDataSource.SqlServer)
-            {
                 if (valueStr is ushort || valueStr is uint || valueStr is ulong)
-                {
                     parameters.Value = Convert.ToInt64(valueStr);
-                }
-            }
             return parameter;
         }
     }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/TimeSpanFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/TimeSpanFieldSetter.cs
@@ -176,6 +176,7 @@ namespace Obase.Providers.Sql.SqlObject
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
+            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
 
             return parameter;
         }

--- a/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
@@ -226,7 +226,7 @@ namespace Obase.Providers.Sql
                             //是否可空
                             var nullable = GetNullable(keyFields, field);
                             var sqliteText = SqlUtils.GetSqliteDbType(field.DataType.ClrType);
-                                sqlBuilder.Append(
+                            sqlBuilder.Append(
                                 keyFields.Contains(field.Name)
                                     ? $"`{field.Name}` {sqliteText} PRIMARY KEY {(field.IsSelfIncreasing ? "AUTOINCREMENT" : "")} {(nullable ? "NULL" : "NOT NULL")},"
                                     : $"`{field.Name}` {sqliteText} {(nullable ? "NULL" : "NOT NULL")},");

--- a/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
@@ -33,7 +33,7 @@ namespace Obase.Providers.Sql
         /// <param name="executor">SQL执行器</param>
         public SqlStorageStructMappingProvider(ISqlExecutor executor)
         {
-            _executor = executor;
+            _executor = executor ?? throw new ArgumentException("存储结构映射的SQL执行器不可为空.");
         }
 
         /// <summary>
@@ -58,9 +58,9 @@ namespace Obase.Providers.Sql
                         sql =
                             $"ALTER TABLE [{tableName}] ADD [{field.Name}] [{SqlUtils.GetSqlServerDbType(field.DataType.ClrType)}] {(nullable ? "NULL" : "NOT NULL")}";
                         //实际上只有字符串类型和decimal类型需要长度 其他类型的长度与具体可以存储的长度无关
-                        if (IsTypeNeedLength(field.DataType.ClrType, field, out var mysqlFieldText))
+                        if (IsTypeNeedLength(field.DataType.ClrType, field, out var sqlServerFieldText))
                             sql =
-                                $"ALTER TABLE {tableName} ADD {field.Name} {mysqlFieldText} {(nullable ? "NULL" : "NOT NULL")}";
+                                $"ALTER TABLE {tableName} ADD {field.Name} {sqlServerFieldText} {(nullable ? "NULL" : "NOT NULL")}";
                         break;
                     case EDataSource.Sqlite:
                         sql =
@@ -70,9 +70,9 @@ namespace Obase.Providers.Sql
                         sql =
                             $"ALTER TABLE `{tableName}` ADD COLUMN `{field.Name}` {SqlUtils.GetMySqlDbType(field.DataType.ClrType)} {(nullable ? "DEFAULT NULL " : "NOT NULL")}";
                         //实际上只有字符串类型和decimal类型需要长度 其他类型的长度与具体可以存储的长度无关
-                        if (IsTypeNeedLength(field.DataType.ClrType, field, out var sqlserverFieldText))
+                        if (IsTypeNeedLength(field.DataType.ClrType, field, out var mySqlFieldText))
                             sql =
-                                $"ALTER TABLE `{tableName}` ADD COLUMN `{field.Name}` {sqlserverFieldText} {(nullable ? "DEFAULT NULL " : "NOT NULL")} ";
+                                $"ALTER TABLE `{tableName}` ADD COLUMN `{field.Name}` {mySqlFieldText} {(nullable ? "DEFAULT NULL " : "NOT NULL")} ";
                         break;
                     case EDataSource.PostgreSql:
                         sql =
@@ -166,8 +166,8 @@ namespace Obase.Providers.Sql
                             //是否可空
                             var nullable = GetNullable(keyFields, field);
                             //实际上只有字符串类型和decimal类型需要长度 其他类型的长度与具体可以存储的长度无关
-                            var filedText = IsTypeNeedLength(field.DataType.ClrType, field, out var mysqlFieldText)
-                                ? mysqlFieldText
+                            var filedText = IsTypeNeedLength(field.DataType.ClrType, field, out var sqlServerFieldText)
+                                ? sqlServerFieldText
                                 : $"[{SqlUtils.GetSqlServerDbType(field.DataType.ClrType)}]";
 
                             sqlBuilder.Append(
@@ -185,8 +185,8 @@ namespace Obase.Providers.Sql
                             //是否可空
                             var nullable = GetNullable(keyFields, field);
                             //实际上只有字符串类型和decimal类型需要长度 其他类型的长度与具体可以存储的长度无关
-                            var filedText = IsTypeNeedLength(field.DataType.ClrType, field, out var mysqlFieldText)
-                                ? mysqlFieldText
+                            var filedText = IsTypeNeedLength(field.DataType.ClrType, field, out var sqlServerFieldText)
+                                ? sqlServerFieldText
                                 : $"[{SqlUtils.GetSqlServerDbType(field.DataType.ClrType)}]";
                             sqlBuilder.Append(
                                 keyFields.Contains(field.Name)
@@ -210,10 +210,11 @@ namespace Obase.Providers.Sql
                         {
                             //是否可空
                             var nullable = GetNullable(keyFields, field);
+                            var sqliteText = SqlUtils.GetSqliteDbType(field.DataType.ClrType);
                             sqlBuilder.Append(
                                 keyFields.Contains(field.Name)
-                                    ? $"`{field.Name}` {SqlUtils.GetSqliteDbType(field.DataType.ClrType)} {(field.IsSelfIncreasing ? "AUTOINCREMENT" : "")} {(nullable ? "NULL" : "NOT NULL")},"
-                                    : $"`{field.Name}` {SqlUtils.GetSqliteDbType(field.DataType.ClrType)} {(nullable ? "NULL" : "NOT NULL")},");
+                                    ? $"`{field.Name}` {sqliteText} {(field.IsSelfIncreasing ? "AUTOINCREMENT" : "")} {(nullable ? "NULL" : "NOT NULL")},"
+                                    : $"`{field.Name}` {sqliteText} {(nullable ? "NULL" : "NOT NULL")},");
                         }
 
                         sqlBuilder.Append($"PRIMARY KEY ({string.Join(",", keyFields)})");
@@ -224,10 +225,11 @@ namespace Obase.Providers.Sql
                         {
                             //是否可空
                             var nullable = GetNullable(keyFields, field);
-                            sqlBuilder.Append(
+                            var sqliteText = SqlUtils.GetSqliteDbType(field.DataType.ClrType);
+                                sqlBuilder.Append(
                                 keyFields.Contains(field.Name)
-                                    ? $"`{field.Name}` {SqlUtils.GetSqliteDbType(field.DataType.ClrType)} PRIMARY KEY {(field.IsSelfIncreasing ? "AUTOINCREMENT" : "")} {(nullable ? "NULL" : "NOT NULL")},"
-                                    : $"`{field.Name}` {SqlUtils.GetSqliteDbType(field.DataType.ClrType)} {(nullable ? "NULL" : "NOT NULL")},");
+                                    ? $"`{field.Name}` {sqliteText} PRIMARY KEY {(field.IsSelfIncreasing ? "AUTOINCREMENT" : "")} {(nullable ? "NULL" : "NOT NULL")},"
+                                    : $"`{field.Name}` {sqliteText} {(nullable ? "NULL" : "NOT NULL")},");
                         }
 
                         sqlBuilder.Remove(sqlBuilder.Length - 1, 1);
@@ -358,12 +360,12 @@ namespace Obase.Providers.Sql
             foreach (var field in fields)
             {
                 string sql;
-                switch (_executor.SourceType)
+                switch (_executor?.SourceType)
                 {
                     case EDataSource.Oracle:
                     case EDataSource.Oledb:
                     case EDataSource.Other:
-                        throw new ArgumentException($"结构映射暂不支持{_executor.SourceType}");
+                        throw new ArgumentException($"结构映射暂不支持{_executor?.SourceType}");
                     case EDataSource.SqlServer:
                         sql = $"SELECT TOP 1 [{tableName}].[{field.Name}] FROM [{tableName}]";
                         break;
@@ -377,7 +379,7 @@ namespace Obase.Providers.Sql
                         sql = $"SELECT \"{tableName}\".\"{field.Name}\" FROM \"{tableName}\" LIMIT 0 OFFSET 1";
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException($"未知的数据源类型{_executor.SourceType}");
+                        throw new ArgumentOutOfRangeException($"未知的数据源类型{_executor?.SourceType}");
                 }
 
                 IDataReader reader = null;
@@ -418,12 +420,12 @@ namespace Obase.Providers.Sql
             foreach (var field in fields)
             {
                 string sql;
-                switch (_executor.SourceType)
+                switch (_executor?.SourceType)
                 {
                     case EDataSource.Oracle:
                     case EDataSource.Oledb:
                     case EDataSource.Other:
-                        throw new ArgumentException($"结构映射暂不支持{_executor.SourceType}");
+                        throw new ArgumentException($"结构映射暂不支持{_executor?.SourceType}");
                     case EDataSource.SqlServer:
                         sql = $"sp_helpindex '{tableName}'";
                         break;
@@ -438,7 +440,7 @@ namespace Obase.Providers.Sql
                         sql = $"Select indexdef FROM pg_indexes Where  tablename = '{tableName}'";
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException($"未知的数据源类型{_executor.SourceType}");
+                        throw new ArgumentOutOfRangeException($"未知的数据源类型{_executor?.SourceType}");
                 }
 
                 IDataReader reader = null;
@@ -566,7 +568,7 @@ namespace Obase.Providers.Sql
                             : $"{SqlUtils.GetMySqlDbType(field.DataType.ClrType)}({length})";
                         break;
                     case EDataSource.Sqlite:
-                        fieldText = $"{SqlUtils.GetMySqlDbType(field.DataType.ClrType)}";
+                        fieldText = $"{SqlUtils.GetSqliteDbType(field.DataType.ClrType)}";
                         break;
                     case EDataSource.PostgreSql:
                         fieldText = length > 255
@@ -574,9 +576,9 @@ namespace Obase.Providers.Sql
                             : $"{SqlUtils.GetPostgreSqlDbType(field.DataType.ClrType)}({length})";
                         break;
                     case EDataSource.SqlServer:
-                        fieldText = length > 255
+                        fieldText = length > 500
                             ? "[Text]"
-                            : $"[{SqlUtils.GetMySqlDbType(field.DataType.ClrType)}]({length})";
+                            : $"[{SqlUtils.GetSqlServerDbType(field.DataType.ClrType)}]({length})";
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(dataSource), dataSource, null);
@@ -602,7 +604,7 @@ namespace Obase.Providers.Sql
                         fieldText = $"{SqlUtils.GetMySqlDbType(field.DataType.ClrType)}";
                         break;
                     case EDataSource.SqlServer:
-                        fieldText = $"[{SqlUtils.GetMySqlDbType(field.DataType.ClrType)}](38,{precision})";
+                        fieldText = $"[{SqlUtils.GetSqlServerDbType(field.DataType.ClrType)}](38,{precision})";
                         break;
                     case EDataSource.PostgreSql:
                         fieldText = $"{SqlUtils.GetPostgreSqlDbType(field.DataType.ClrType)}(65,{precision})";

--- a/Src/UnitTest/Obase.Test/CoreTest/FunctionalTest/TransactionTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/FunctionalTest/TransactionTest.cs
@@ -430,7 +430,7 @@ public class TransactionTest
         }
 
         //检验是否发生异常
-        Assert.That(exception,Is.Not.Null);
+        Assert.That(exception, Is.Not.Null);
 
         //都回滚了 没有插入数据
         count = context.CreateSet<NullableJavaBean>().Count(p => p.IntNumber == 23);


### PR DESCRIPTION
- 增加完整性检查时检查是否所有的关联端实体型主键都有映射.
- 增加完整性检查时检查启用了延迟加载的引用元素对应的属性是否为virtual.
- 修复SqlServer建表时错误的将字符串类型设置为varchar类型的问题,应为nvarchar.
- 增加SqlServer数据源的ushort,uint,ulong类型参数化时转化为有符号数的逻辑.
- 修复SqlServer数据源的DateTime类型参数化时空值没有转换为DBNull的问题.