### PR TITLE
合并6.4.3的改动

### DIFF
--- a/ChangeLogs/6.4.3.md
+++ b/ChangeLogs/6.4.3.md
@@ -5,5 +5,6 @@
 2. Obase.Providers.Sql
    - 修复自动建表时,重复的关联端映射导致建索引失败的问题.
    - 修复某个关联型的多个关联端映射间存在重叠的映射字段时,排序字段生成的错误.
+   - 修改自动建表时,字符串类型的字段默认映射长度为40,Decima类型的字段默认精度小数位为4.
 3. Obase.Odm.Annotation/Obase.LogicDeletion/Obase.MultiTenant/Obase.Providers.MySql/Obase.Providers.Oracle/Obase.Providers.SqlServer/Obase.Providers.Sqlite/Obase.Providers.PostgreSql
    - 无实质更新,仅更新版本号.

--- a/ChangeLogs/6.4.3.md
+++ b/ChangeLogs/6.4.3.md
@@ -1,0 +1,9 @@
+# 6.4.3
+1. Obase.Core
+   - 增加完整性检查时关联引用的左端和右端名称不能为相同的检查.
+   - 修复显式关联的关联引用自动侦测左端右端时有可能设置错误的右端名的问题.
+2. Obase.Providers.Sql
+   - 修复自动建表时,重复的关联端映射导致建索引失败的问题.
+   - 修复某个关联型的多个关联端映射间存在重叠的映射字段时,排序字段生成的错误.
+3. Obase.Odm.Annotation/Obase.LogicDeletion/Obase.MultiTenant/Obase.Providers.MySql/Obase.Providers.Oracle/Obase.Providers.SqlServer/Obase.Providers.Sqlite/Obase.Providers.PostgreSql
+   - 无实质更新,仅更新版本号.

--- a/ChangeLogs/6.4.3.md
+++ b/ChangeLogs/6.4.3.md
@@ -1,10 +1,12 @@
 # 6.4.3
 1. Obase.Core
-   - 增加完整性检查时关联引用的左端和右端名称不能为相同的检查.
+   - 增加完整性检查时关联引用的左端和右端名称不能相同的检查.
+   - 增加完整性检查时继承关系中是否都使用相同映射表的检查.
    - 修复显式关联的关联引用自动侦测左端右端时有可能设置错误的右端名的问题.
 2. Obase.Providers.Sql
    - 修复自动建表时,重复的关联端映射导致建索引失败的问题.
    - 修复某个关联型的多个关联端映射间存在重叠的映射字段时,排序字段生成的错误.
-   - 修改自动建表时,字符串类型的字段默认映射长度为40,Decima类型的字段默认精度小数位为4.
+   - 修改自动建表时字符串类型的字段默认映射长度为40.
+   - 修复一个在使用投影之后再用关联属性排序时生成的Sql语句别名错误的问题.
 3. Obase.Odm.Annotation/Obase.LogicDeletion/Obase.MultiTenant/Obase.Providers.MySql/Obase.Providers.Oracle/Obase.Providers.SqlServer/Obase.Providers.Sqlite/Obase.Providers.PostgreSql
    - 无实质更新,仅更新版本号.

--- a/Src/Obase/Directory.Build.props
+++ b/Src/Obase/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- 统一配置包版本 -->
-    <PackageVersion>6.4.2</PackageVersion>
+    <PackageVersion>6.4.3</PackageVersion>
     <!-- 统一配置输出路径 -->
     <OutputPath>../Output/</OutputPath>
     <!-- 统一配置目标框架 -->

--- a/Src/Obase/Obase.Core/Odm/AssociationType.cs
+++ b/Src/Obase/Obase.Core/Odm/AssociationType.cs
@@ -328,7 +328,7 @@ namespace Obase.Core.Odm
                         var mapCount = end.Mappings.Count(p => p.KeyAttribute == entityTypeKeyAttribute);
                         if (mapCount != 1)
                             message.Add(
-                                $"关联型{Name}的关联端{end.Name}的标识属性{entityTypeKeyAttribute}应有且只1个映射,但现在有{mapCount}个映射.");
+                                $"关联型{Name}的{end.EntityType.ClrType}类型关联端{end.Name}的标识属性{entityTypeKeyAttribute}应有且只1个映射,但现在有{mapCount}个映射.");
                     }
                 }
 

--- a/Src/Obase/Obase.Core/Odm/Builder/DefaultTypeMemberAnalyzer.cs
+++ b/Src/Obase/Obase.Core/Odm/Builder/DefaultTypeMemberAnalyzer.cs
@@ -172,6 +172,10 @@ namespace Obase.Core.Odm.Builder
                         {
                             //查找显式关联型的各个属性
                             var obviousProps = obvious.ClrType.GetProperties();
+                            //只保留与关联端类型相同的属性
+                            var endType = ((IAssociationTypeConfigurator)obvious).AssociationEnds
+                                .Select(p => p.EntityType).ToList();
+                            obviousProps = obviousProps.Where(p => endType.Contains(p.PropertyType)).ToArray();
                             //配置左端右端
                             ConfigLeftAndRight(configurator, obviousProps, propertyInfo, type);
                         }
@@ -337,8 +341,8 @@ namespace Obase.Core.Odm.Builder
             //与当前属性所在类的类型相同 推断为左端
             var leftEnd = props.FirstOrDefault(p => p.PropertyType == propertyInfo.ReflectedType)?.Name;
             if (!string.IsNullOrEmpty(leftEnd)) configurator.HasLeftEnd(leftEnd, false);
-            //与当前属性类型相同 推断为右端
-            var rightEnd = props.FirstOrDefault(p => p.PropertyType == type || p.ReflectedType == type)?.Name;
+            //另外一端 推断为右端
+            var rightEnd = props.FirstOrDefault(p => p.Name != leftEnd)?.Name;
             if (!string.IsNullOrEmpty(rightEnd)) configurator.HasRightEnd(rightEnd, false);
         }
     }

--- a/Src/Obase/Obase.Core/Odm/EntityType.cs
+++ b/Src/Obase/Obase.Core/Odm/EntityType.cs
@@ -260,6 +260,10 @@ namespace Obase.Core.Odm
                 if (reference.ValueSetter == null)
                     message.Add(
                         $"{ClrType}的关联引用{reference.Name}没有设值器.");
+
+                //检查左端是否和右端相同
+                if(reference.LeftEnd == reference.RightEnd)
+                    message.Add($"{ClrType}的关联引用{reference.Name}的左端和右端不能相同.");
             }
 
             //检查键属性

--- a/Src/Obase/Obase.Core/Odm/EntityType.cs
+++ b/Src/Obase/Obase.Core/Odm/EntityType.cs
@@ -262,7 +262,7 @@ namespace Obase.Core.Odm
                         $"{ClrType}的关联引用{reference.Name}没有设值器.");
 
                 //检查左端是否和右端相同
-                if(reference.LeftEnd == reference.RightEnd)
+                if (reference.LeftEnd == reference.RightEnd)
                     message.Add($"{ClrType}的关联引用{reference.Name}的左端和右端不能相同.");
             }
 

--- a/Src/Obase/Obase.Core/Odm/ObjectType.cs
+++ b/Src/Obase/Obase.Core/Odm/ObjectType.cs
@@ -204,6 +204,11 @@ namespace Obase.Core.Odm
                 message.Add($"{_clrType}配置为继承{DerivingFrom.ClrType},却没有配置具体类型判别标志.");
             if (DerivedTypes.Count > 0 && ConcreteTypeSign == null)
                 message.Add($"{_clrType}配置为基础类型,却没有配置具体类型判别标志.");
+            //检查继承的映射表是否一致
+            if (DerivingFrom is ObjectType derivingObjectType)
+                if (derivingObjectType.TargetTable != TargetTable)
+                    message.Add(
+                        $"{_clrType}配置为继承{DerivingFrom.ClrType},但映射表与父类不一致,父类映射表为{derivingObjectType.TargetTable},当前为{TargetTable}.");
 
             //检查父类的构造器
             if (DerivingFrom != null)

--- a/Src/Obase/Obase.Core/Odm/ObjectType.cs
+++ b/Src/Obase/Obase.Core/Odm/ObjectType.cs
@@ -244,7 +244,6 @@ namespace Obase.Core.Odm
 
             //检查引用元素的延迟加载配置
             if (ReferenceElements != null)
-            {
                 foreach (var referenceElement in ReferenceElements)
                 {
                     //检查引用元素的get方法
@@ -253,8 +252,7 @@ namespace Obase.Core.Odm
                     if (getMethod != null && !getMethod.IsVirtual && referenceElement.EnableLazyLoading)
                         message.Add($"对象类型{Name}的引用元素{referenceElement.Name}启用了延迟加载,但没有将其声明为virtual的.");
                 }
-            }
-            
+
 
             //如果有检查失败消息
             if (message.Any())

--- a/Src/Obase/Obase.Core/StorageStructMappingExecutor.cs
+++ b/Src/Obase/Obase.Core/StorageStructMappingExecutor.cs
@@ -78,6 +78,7 @@ namespace Obase.Core
 
                         //合并去重
                         attrFields = attrFields.GroupBy(p => p.Name).Select(p => p.ToList().First()).ToList();
+                        endFields = endFields.Distinct().ToList();
                         EnsureTable(associationType.TargetTable, endFields.ToArray(), attrFields.ToArray(), provider);
                     }
                     else

--- a/Src/Obase/Obase.Providers.Sql/Common/SqlUtils.cs
+++ b/Src/Obase/Obase.Providers.Sql/Common/SqlUtils.cs
@@ -408,5 +408,25 @@ namespace Obase.Providers.Sql.Common
 
             throw new ArgumentException($"无法为{targetField}({dataType.Name})生成条件,请检查此属性的配置属性类型和取值器设值器.");
         }
+
+        /// <summary>
+        ///     排序字段去重
+        /// </summary>
+        /// <param name="orders">排序字段列表</param>
+        /// <returns></returns>
+        public static List<Order> DistinctOrders(List<Order> orders)
+        {
+            //如果存在同一个Field的仅保留一个
+            var orderSet = new HashSet<string>();
+            var list = new List<Order>();
+            foreach (var order in orders)
+            {
+                var orderStr = order.ToString(EDataSource.SqlServer).Replace("Desc", "").Replace("Asc", "");
+                //使用HashSet去重
+                if (orderSet.Add(orderStr)) list.Add(order);
+            }
+
+            return list;
+        }
     }
 }

--- a/Src/Obase/Obase.Providers.Sql/Rop/MemberExpressionExtension.cs
+++ b/Src/Obase/Obase.Providers.Sql/Rop/MemberExpressionExtension.cs
@@ -79,9 +79,14 @@ namespace Obase.Providers.Sql.Rop
                 else
                 {
                     var tailType = assoTail.RepresentedType;
-                    source = tailType is ObjectType objectType
-                        ? new SimpleSource(objectType.TargetName, Utils.GetDerivedTargetTable(objectType))
-                        : new SimpleSource(((IMappable)tailType)?.TargetName);
+
+                    if (tailType is ObjectType objectType)
+                        //默认不设值别名 除非是继承
+                        source = objectType.DerivingFrom != null
+                            ? new SimpleSource(objectType.TargetName, Utils.GetDerivedTargetTable(objectType))
+                            : new SimpleSource(objectType.TargetName);
+                    else
+                        source = new SimpleSource(((IMappable)tailType)?.TargetName);
                 }
             }
 

--- a/Src/Obase/Obase.Providers.Sql/Rop/RopContext.cs
+++ b/Src/Obase/Obase.Providers.Sql/Rop/RopContext.cs
@@ -152,6 +152,9 @@ namespace Obase.Providers.Sql.Rop
             _targetSource = targetSource;
         }
 
+        /// <summary>
+        ///     别名生成器，用于生成退化路径和包含树各节点的别名。需要时创建。
+        /// </summary>
         private AliasGenerator AliasGenerator => _aliasGenerator ?? (_aliasGenerator = new AliasGenerator());
 
         /// <summary>

--- a/Src/Obase/Obase.Providers.Sql/Rop/RopContext.cs
+++ b/Src/Obase/Obase.Providers.Sql/Rop/RopContext.cs
@@ -121,14 +121,16 @@ namespace Obase.Providers.Sql.Rop
             _resultModelType = _model.GetObjectType(initialType);
             IncludingConstructorParameter();
 
-
+            //构造初始源
             var objType = Model.GetObjectType(InitialType);
             var sourceName = objType.TargetTable;
             var orderRules = objType.StoringOrder;
+            //默认不设值别名 除非是继承
+            _initialSource = objType.DerivingFrom == null
+                ? new SimpleSource(sourceName)
+                : new SimpleSource(sourceName, Utils.GetDerivedTargetTable(objType));
 
-            var alias = Utils.GetDerivedTargetTable(objType);
-            _initialSource = alias == sourceName ? new SimpleSource(sourceName) : new SimpleSource(sourceName, alias);
-
+            //处理排序
             var orders = new List<Order>();
             foreach (var r in orderRules ?? new List<OrderRule>())
             {

--- a/Src/Obase/Obase.Providers.Sql/Rop/RopTerminator.cs
+++ b/Src/Obase/Obase.Providers.Sql/Rop/RopTerminator.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using Obase.Core.Odm;
 using Obase.Core.Odm.ObjectSys;
 using Obase.Core.Query;
+using Obase.Providers.Sql.Common;
 using Obase.Providers.Sql.SqlObject;
 using Attribute = Obase.Core.Odm.Attribute;
 
@@ -131,15 +132,7 @@ namespace Obase.Providers.Sql.Rop
             }
 
             //如果存在同一个Field的仅保留一个
-            var orderSet = new HashSet<string>();
-            var list = new List<Order>();
-            foreach (var order in context.ResultSql.Orders)
-            {
-                var orderStr = order.ToString(EDataSource.SqlServer).Replace("Desc", "").Replace("Asc", "");
-                if (orderSet.Add(orderStr)) list.Add(order);
-            }
-
-            context.ResultSql.Orders = list;
+            context.ResultSql.Orders = SqlUtils.DistinctOrders(context.ResultSql.Orders);
         }
     }
 }

--- a/Src/Obase/Obase.Providers.Sql/Rop/SourceAliasRootSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/Rop/SourceAliasRootSetter.cs
@@ -37,7 +37,7 @@ namespace Obase.Providers.Sql.Rop
         protected override Expression VisitField(FieldExpression field)
         {
             if (!string.IsNullOrEmpty(_aliasRoot) && field.Field.Source is SimpleSource source)
-                source.SetAliasRoot(_aliasRoot);
+                source.SetSymbolPrefix(_aliasRoot);
             return field;
         }
     }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/MonomerSource.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/MonomerSource.cs
@@ -7,6 +7,7 @@
 └──────────────────────────────────────────────────────────────┘
 */
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 
@@ -91,6 +92,7 @@ namespace Obase.Providers.Sql.SqlObject
         ///     为源设置别名根。
         /// </summary>
         /// <param name="aliasRoot">要设置的别名根。</param>
+        [Obsolete("请使用SetSymbolPrefix方法替代", true)]
         internal abstract void SetAliasRoot(string aliasRoot);
 
         /// <summary>

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/QuerySql.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/QuerySql.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Text;
+using Obase.Providers.Sql.Common;
 
 namespace Obase.Providers.Sql.SqlObject
 {
@@ -688,10 +689,11 @@ namespace Obase.Providers.Sql.SqlObject
                     if (Orders != null && Orders.Count > 0)
                     {
                         orderStringBuilder.Append(" order by ");
-                        for (var i = 0; i < Orders.Count; i++)
+                        var orders = SqlUtils.DistinctOrders(Orders);
+                        for (var i = 0; i < orders.Count; i++)
                         {
-                            var order = Orders[i];
-                            orderStringBuilder.Append(i != Orders.Count - 1
+                            var order = orders[i];
+                            orderStringBuilder.Append(i != orders.Count - 1
                                 ? $" {order.Expression.ToString(sourceType)} {order.Direction},"
                                 : $" {order.Expression.ToString(sourceType)} {order.Direction}");
                         }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/SelectSource.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/SelectSource.cs
@@ -175,6 +175,7 @@ namespace Obase.Providers.Sql.SqlObject
         ///     为源设置别名根。
         /// </summary>
         /// <param name="aliasRoot">要设置的别名根。</param>
+        [Obsolete("请使用SetSymbolPrefix方法替代", true)]
         internal override void SetAliasRoot(string aliasRoot)
         {
             _name = aliasRoot;

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/SetSource.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/SetSource.cs
@@ -151,6 +151,7 @@ namespace Obase.Providers.Sql.SqlObject
         ///     为源设置别名根。
         /// </summary>
         /// <param name="aliasRoot">要设置的别名根。</param>
+        [Obsolete("请使用SetSymbolPrefix方法替代", true)]
         internal override void SetAliasRoot(string aliasRoot)
         {
             _name = aliasRoot;

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/SimpleSource.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/SimpleSource.cs
@@ -19,14 +19,14 @@ namespace Obase.Providers.Sql.SqlObject
     public class SimpleSource : MonomerSource
     {
         /// <summary>
+        ///     指代符，该指代符用于在Sql语句的其它部分引用源。
+        /// </summary>
+        private string _alias;
+
+        /// <summary>
         ///     名称
         /// </summary>
         private string _name;
-
-        /// <summary>
-        ///     指代符，该指代符用于在Sql语句的其它部分引用源。
-        /// </summary>
-        private string _symbol;
 
         /// <summary>
         ///     创建简单查询源实例。
@@ -45,7 +45,7 @@ namespace Obase.Providers.Sql.SqlObject
         public SimpleSource(string name, string alias)
         {
             _name = name;
-            _symbol = alias;
+            _alias = alias;
         }
 
         /// <summary>
@@ -71,12 +71,12 @@ namespace Obase.Providers.Sql.SqlObject
         /// <summary>
         ///     获取指代符，该指代符用于在Sql语句的其它部分引用源。
         /// </summary>
-        public override string Symbol => _symbol ?? _name;
+        public override string Symbol => _alias ?? _name;
 
         /// <summary>
-        ///     获取源的别名 同指代符
+        ///     获取源的别名
         /// </summary>
-        public string Alias => _symbol ?? _name;
+        public string Alias => _alias;
 
         /// <summary>
         ///     将简单源的存储顺序（StoringOrder）提升为指定查询的排序规则。
@@ -187,9 +187,10 @@ namespace Obase.Providers.Sql.SqlObject
         ///     为源设置别名根。
         /// </summary>
         /// <param name="aliasRoot">要设置的别名根。</param>
+        [Obsolete("请使用SetSymbolPrefix方法替代", true)]
         internal override void SetAliasRoot(string aliasRoot)
         {
-            _symbol = aliasRoot;
+            _alias = aliasRoot;
         }
 
         /// <summary>
@@ -199,7 +200,7 @@ namespace Obase.Providers.Sql.SqlObject
         public override void SetSymbolPrefix(string prefix)
         {
             //设置指代符前缀即在别名前加上前缀。
-            _symbol = prefix + _symbol;
+            _alias = prefix + _alias;
         }
 
         /// <summary>
@@ -207,7 +208,7 @@ namespace Obase.Providers.Sql.SqlObject
         /// </summary>
         public override void ResetSymbol()
         {
-            _symbol = null;
+            _alias = null;
         }
 
         /// <summary>
@@ -242,7 +243,7 @@ namespace Obase.Providers.Sql.SqlObject
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return _name == other._name && _symbol == other._symbol;
+            return _name == other._name && _alias == other._alias;
         }
 
         /// <summary>
@@ -267,7 +268,7 @@ namespace Obase.Providers.Sql.SqlObject
             unchecked
             {
                 var hashCode = _name != null ? _name.GetHashCode() : 0;
-                hashCode = (hashCode * 397) ^ (_symbol != null ? _symbol.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (_alias != null ? _alias.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
@@ -591,12 +591,6 @@ namespace Obase.Providers.Sql
             if (type == typeof(decimal))
             {
                 var precision = field.Precision;
-                //默认为4位小数
-                if(precision == 0)
-                    precision = 4;
-                //最大30位小数
-                if (precision >= 30)
-                    precision = 30;
 
                 switch (dataSource)
                 {

--- a/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlStorageStructMappingProvider.cs
@@ -555,7 +555,7 @@ namespace Obase.Providers.Sql
             //字符串类型
             if (type == typeof(string) || type == typeof(Guid))
             {
-                var length = field.Length / 8 == 0 ? 255 : field.Length / 8;
+                var length = field.Length / 8 == 0 ? 40 : field.Length / 8;
                 switch (dataSource)
                 {
                     case EDataSource.Oracle:
@@ -591,6 +591,13 @@ namespace Obase.Providers.Sql
             if (type == typeof(decimal))
             {
                 var precision = field.Precision;
+                //默认为4位小数
+                if(precision == 0)
+                    precision = 4;
+                //最大30位小数
+                if (precision >= 30)
+                    precision = 30;
+
                 switch (dataSource)
                 {
                     case EDataSource.Oracle:

--- a/Src/UnitTest/Obase.Test.Domain/Association/DuplicateMapping/GoodsAttribute.cs
+++ b/Src/UnitTest/Obase.Test.Domain/Association/DuplicateMapping/GoodsAttribute.cs
@@ -1,0 +1,67 @@
+﻿namespace Obase.Test.Domain.Association.DuplicateMapping;
+
+/// <summary>
+///     表示在一个商品上为某一个属性设置了值，简称商品属性。
+/// </summary>
+public class GoodsAttribute
+{
+    /// <summary>
+    ///     属性的标识。
+    /// </summary>
+    private long _attributeId;
+
+    /// <summary>
+    ///     商品的标识。
+    /// </summary>
+    private long _goodsId;
+
+    /// <summary>
+    ///     该商品属性的输入值（与标准值对举）。
+    /// </summary>
+    private string _inputValue;
+
+    /// <summary>
+    ///     初始化GoodsAttribute类的新实例。
+    /// </summary>
+    /// <param name="goodsId">商品的标识。</param>
+    /// <param name="attributeId">属性的标识。</param>
+    public GoodsAttribute(long goodsId, long attributeId)
+    {
+        GoodsId = goodsId;
+        AttributeId = attributeId;
+    }
+
+    /// <summary>
+    ///     供对象重建（如反持久化）使用的构造函数。
+    /// </summary>
+    protected GoodsAttribute()
+    {
+    }
+
+    /// <summary>
+    ///     获取属性的标识。
+    /// </summary>
+    public long AttributeId
+    {
+        get => _attributeId;
+        protected internal set => _attributeId = value;
+    }
+
+    /// <summary>
+    ///     获取商品的标识。
+    /// </summary>
+    public long GoodsId
+    {
+        get => _goodsId;
+        protected internal set => _goodsId = value;
+    }
+
+    /// <summary>
+    ///     获取或设置该商品属性的输入值（与标准值对举）。
+    /// </summary>
+    public string InputValue
+    {
+        get => _inputValue;
+        set => _inputValue = value;
+    }
+}

--- a/Src/UnitTest/Obase.Test.Domain/Association/DuplicateMapping/SelectableValue.cs
+++ b/Src/UnitTest/Obase.Test.Domain/Association/DuplicateMapping/SelectableValue.cs
@@ -1,0 +1,81 @@
+﻿namespace Obase.Test.Domain.Association.DuplicateMapping;
+
+/// <summary>
+///     表示一个属性值可以作为某一类目属性的可选值。
+/// </summary>
+public class SelectableValue
+{
+    /// <summary>
+    ///     作为当前属性的可选值时的别名。
+    /// </summary>
+    private string _alias;
+
+    /// <summary>
+    ///     属性的标识。
+    /// </summary>
+    private long _attributeId;
+
+    /// <summary>
+    ///     类目的标识。
+    /// </summary>
+    private long _categoryId;
+
+    /// <summary>
+    ///     在当前属性可选值集合中的排序。
+    /// </summary>
+    private int _sequence;
+
+    /// <summary>
+    ///     SelectableValue类的新实例。
+    /// </summary>
+    /// <param name="categoryId">类目的标识。</param>
+    /// <param name="attributeId">属性的标识。</param>
+    public SelectableValue(long categoryId, long attributeId)
+    {
+        CategoryId = categoryId;
+        AttributeId = attributeId;
+    }
+
+    /// <summary>
+    ///     供对象重建（如反持久化）使用的构造函数。
+    /// </summary>
+    protected SelectableValue()
+    {
+    }
+
+    /// <summary>
+    ///     获取属性的标识。
+    /// </summary>
+    public long AttributeId
+    {
+        get => _attributeId;
+        protected internal set => _attributeId = value;
+    }
+
+    /// <summary>
+    ///     作为当前属性的可选值时的别名。
+    /// </summary>
+    public string Alias
+    {
+        get => _alias;
+        set => _alias = value;
+    }
+
+    /// <summary>
+    ///     类目的标识。
+    /// </summary>
+    public long CategoryId
+    {
+        get => _categoryId;
+        protected internal set => _categoryId = value;
+    }
+
+    /// <summary>
+    ///     在当前属性可选值集合中的排序。
+    /// </summary>
+    public int Sequence
+    {
+        get => _sequence;
+        set => _sequence = value;
+    }
+}

--- a/Src/UnitTest/Obase.Test.Domain/Association/DuplicateMapping/StandardValue.cs
+++ b/Src/UnitTest/Obase.Test.Domain/Association/DuplicateMapping/StandardValue.cs
@@ -1,0 +1,140 @@
+﻿namespace Obase.Test.Domain.Association.DuplicateMapping;
+
+/// <summary>
+///     表示为一个商品属性从可选值清单中选定了一个值
+/// </summary>
+public class StandardValue
+{
+    /// <summary>
+    ///     取值别名，即属性值作为当前商品属性的取值时的别名。
+    /// </summary>
+    private string _alias;
+
+    /// <summary>
+    ///     属性的标识。
+    /// </summary>
+    private long _attributeId;
+
+    /// <summary>
+    ///     商品所属类目的标识。
+    /// </summary>
+    private long _categoryId;
+
+    /// <summary>
+    ///     商品属性。
+    /// </summary>
+    private GoodsAttribute _goodsAttribute;
+
+    /// <summary>
+    ///     商品的标识。
+    /// </summary>
+    private long _goodsId;
+
+    /// <summary>
+    ///     属性图片，即针对商品的特定属性（如颜色为红色）拍摄的展示图片。
+    /// </summary>
+    private string _photo;
+
+    /// <summary>
+    ///     被选中的属性值。
+    /// </summary>
+    private SelectableValue _selectedValue;
+
+    /// <summary>
+    ///     属性值的标识。
+    /// </summary>
+    private long _valueId;
+
+
+    /// <summary>
+    ///     初始化StandardValue类的新实例。
+    /// </summary>
+    /// <param name="goodsAttribute">商品属性。</param>
+    /// <param name="selectedValue">被选中的属性值。</param>
+    public StandardValue(GoodsAttribute goodsAttribute, SelectableValue selectedValue)
+    {
+        GoodsAttribute = goodsAttribute;
+        SelectedValue = selectedValue;
+    }
+
+    /// <summary>
+    ///     供对象重建（如反持久化）使用的构造函数。
+    /// </summary>
+    protected StandardValue()
+    {
+    }
+
+    /// <summary>
+    ///     获取或设置取值别名，取值别名是属性值作为当前商品属性的取值时的别名。
+    /// </summary>
+    public string Alias
+    {
+        get => _alias;
+        set => _alias = value;
+    }
+
+    /// <summary>
+    ///     获取属性的标识。
+    /// </summary>
+    public long AttributeId
+    {
+        get => _attributeId;
+        protected internal set => _attributeId = value;
+    }
+
+    /// <summary>
+    ///     商品所属类目的标识。
+    /// </summary>
+    public long CategoryId
+    {
+        get => _categoryId;
+        protected internal set => _categoryId = value;
+    }
+
+    /// <summary>
+    ///     获取商品属性。
+    /// </summary>
+    public GoodsAttribute GoodsAttribute
+    {
+        get => _goodsAttribute;
+        protected internal set => _goodsAttribute = value;
+    }
+
+    /// <summary>
+    ///     获取商品的标识。
+    /// </summary>
+    public long GoodsId
+    {
+        get => _goodsId;
+        protected internal set => _goodsId = value;
+    }
+
+    /// <summary>
+    ///     获取或设置属性图片，属性图片是指针对商品的特定属性（如颜色为红色）拍摄的展示图片。
+    /// </summary>
+    public string Photo
+    {
+        get => _photo;
+        set => _photo = value;
+    }
+
+    /// <summary>
+    ///     获取属性的取值。
+    ///     实施说明
+    ///     如果未加载属性的取值，使用其仓储加载；应寄存加载结果，避免重复加载。
+    /// </summary>
+    public SelectableValue SelectedValue
+    {
+        get => _selectedValue;
+        protected internal set => _selectedValue = value;
+    }
+
+    /// <summary>
+    ///     获取属性值的标识。
+    /// </summary>
+    public long ValueId
+    {
+        get => _valueId;
+        protected internal set => _valueId = value;
+    }
+}

--- a/Src/UnitTest/Obase.Test.Infrastructure/ModelRegister/CoreModelRegister.cs
+++ b/Src/UnitTest/Obase.Test.Infrastructure/ModelRegister/CoreModelRegister.cs
@@ -6,6 +6,7 @@ using Obase.Core.Odm;
 using Obase.Core.Odm.Builder;
 using Obase.Test.Domain.Association;
 using Obase.Test.Domain.Association.DefaultAsNew;
+using Obase.Test.Domain.Association.DuplicateMapping;
 using Obase.Test.Domain.Association.ExplicitlyCompion;
 using Obase.Test.Domain.Association.ExplicitlySelf;
 using Obase.Test.Domain.Association.Implement;
@@ -660,6 +661,11 @@ public static class CoreModelRegister
         //第一个关联端 Product 此关联端在关联表PropertyTakingValue中的映射为Product的主键Code映射为ProductCode
         //第二个关联端 Property 此关联端在关联表PropertyTakingValue中的映射为Property的主键Code映射为PropertyCode
         //第三个关联端 PropertyValue 此关联端在关联表PropertyTakingValue中的映射为PropertyValue的主键Code映射为PropertyValueCode
+        var explicitPropertyValue = modelBuilder.Association<PropertyTakingValue>();
+        explicitPropertyValue.AssociationEnd(p => p.Product).HasMapping("Code", "ProductCode");
+        explicitPropertyValue.AssociationEnd(p => p.Property).HasMapping("Code", "PropertyCode");
+        explicitPropertyValue.AssociationEnd(p => p.PropertyValue).HasMapping("Code", "PropertyValueCode");
+        explicitPropertyValue.ToTable("PropertyTakingValue");
 
         //配置隐式的多方关联的关联型
         //使用元组作为关联引用的类型 即可被解析为隐式的多方关联的关联型
@@ -1197,6 +1203,32 @@ public static class CoreModelRegister
         noticeEntityConfig.HasNotifyDeletion(true);
         //指示是否在对象被修改时进行通知
         noticeEntityConfig.HasNotifyUpdate(true);
+
+        #endregion
+
+        //对应测试文件CoreTest/AssociationTest文件夹内DuplicateMappingTest
+
+        #region 重复映射(独立映射表中关联端映射字段有重复)
+
+        //配置GoodsAttribute实体型
+        var goodsAttributeEntity = modelBuilder.Entity<GoodsAttribute>();
+        goodsAttributeEntity.HasKeyAttribute(p => p.AttributeId).HasKeyAttribute(p => p.GoodsId)
+            .HasKeyIsSelfIncreased(false);
+        goodsAttributeEntity.ToTable("GoodsAttributes");
+
+        //配置SelectableValue实体型
+        var selectableValueEntity = modelBuilder.Entity<SelectableValue>();
+        selectableValueEntity.HasKeyAttribute(p => p.CategoryId).HasKeyAttribute(p => p.AttributeId)
+            .HasKeyIsSelfIncreased(false);
+        selectableValueEntity.ToTable("SelectableValues");
+
+        //配置StandardValue关联型
+        var standardValueAssociation = modelBuilder.Association<StandardValue>();
+        standardValueAssociation.AssociationEnd(p => p.GoodsAttribute).HasMapping("AttributeId", "AttributeId")
+            .HasMapping("GoodsId", "GoodsId");
+        standardValueAssociation.AssociationEnd(p => p.SelectedValue).HasMapping("CategoryId", "CategoryId")
+            .HasMapping("AttributeId", "AttributeId");
+        standardValueAssociation.ToTable("StandardValue");
 
         #endregion
     }

--- a/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/AssociationQueryTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/AssociationQueryTest.cs
@@ -1,10 +1,10 @@
-﻿using Obase.Core;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Obase.Core;
 using Obase.Providers.Sql;
 using Obase.Test.Configuration;
 using Obase.Test.Domain.Association;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Obase.Test.CoreTest.AssociationTest;
 
@@ -310,12 +310,11 @@ public class AssociationQueryTest
 
         Assert.That(classes.Count, Is.EqualTo(1));
 
-        //此BUG未修改 暂时不进行测试 对应ISSUE CNB的#25
         //投影之后 使用学生名称 和 学生关联的班级关联的学校创建时间排序
-        //var oStud = context.CreateSet<Class>().SelectMany(p => p.Students)
-        //    .OrderBy(p => p.Name).ThenBy(p => p.Class.School.Createtime).ToList();
+        var oStud = context.CreateSet<Class>().SelectMany(p => p.Students)
+            .OrderBy(p => p.Name).ThenBy(p => p.Class.School.Createtime).ToList();
 
-        //Assert.That(oStud.Count, Is.EqualTo(5));
+        Assert.That(oStud.Count, Is.EqualTo(5));
     }
 
     /// <summary>

--- a/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/AssociationQueryTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/AssociationQueryTest.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Obase.Core;
+﻿using Obase.Core;
 using Obase.Providers.Sql;
 using Obase.Test.Configuration;
 using Obase.Test.Domain.Association;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Obase.Test.CoreTest.AssociationTest;
 
@@ -294,6 +294,29 @@ public class AssociationQueryTest
             Is.EqualTo("无法从Obase.Test.Domain.Association.School中获取属性456,请检查Include的参数. (Parameter 'sourceType')"));
     }
 
+    /// <summary>
+    ///     测试排序
+    /// </summary>
+    /// <param name="dataSource"></param>
+    [TestCaseSource(typeof(TestCaseSourceConfigurationManager),
+        nameof(TestCaseSourceConfigurationManager.DataSourceTestCases))]
+    public void OrderTest(EDataSource dataSource)
+    {
+        //测试用关联属性排序
+        var context = ContextUtils.CreateContext(dataSource);
+        //使用班级名称 和 班级关联的学校创建时间排序
+        var classes = context.CreateSet<Class>()
+            .OrderBy(p => p.Name).ThenBy(p => p.School.Createtime).ToList();
+
+        Assert.That(classes.Count, Is.EqualTo(1));
+
+        //此BUG未修改 暂时不进行测试 对应ISSUE CNB的#25
+        //投影之后 使用学生名称 和 学生关联的班级关联的学校创建时间排序
+        //var oStud = context.CreateSet<Class>().SelectMany(p => p.Students)
+        //    .OrderBy(p => p.Name).ThenBy(p => p.Class.School.Createtime).ToList();
+
+        //Assert.That(oStud.Count, Is.EqualTo(5));
+    }
 
     /// <summary>
     ///     测试投影

--- a/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/DuplicateMappingTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/DuplicateMappingTest.cs
@@ -1,0 +1,110 @@
+﻿using System.Linq;
+using Obase.Core;
+using Obase.Providers.Sql;
+using Obase.Test.Configuration;
+using Obase.Test.Domain.Association.DuplicateMapping;
+
+namespace Obase.Test.CoreTest.AssociationTest;
+
+/// <summary>
+///     在关联型中有重复的映射测试
+/// </summary>
+[TestFixture]
+public class DuplicateMappingTest
+{
+    /// <summary>
+    ///     构造实例 装载初始对象
+    /// </summary>
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        foreach (var dataSource in TestCaseSourceConfigurationManager.DataSources)
+        {
+            var context = ContextUtils.CreateContext(dataSource);
+            //清理可能的冗余数据
+            context.CreateSet<GoodsAttribute>().Delete(p => p.AttributeId > 0 || p.GoodsId > 0);
+            context.CreateSet<SelectableValue>().Delete(p => p.AttributeId > 0 || p.CategoryId > 0);
+            context.CreateSet<StandardValue>().Delete(p => p.AttributeId > 0 || p.CategoryId > 0 || p.GoodsId > 0);
+
+            context = ContextUtils.CreateContext(dataSource);
+
+            //加入测试数据
+            var gen = new TimeBasedIdGenerator();
+
+            var goodsAttr = new GoodsAttribute(gen.Next(), gen.Next())
+            {
+                InputValue = "测试输入值"
+            };
+            var selectableValue = new SelectableValue(gen.Next(), goodsAttr.AttributeId)
+            {
+                Alias = "测试属性值",
+                Sequence = 10
+            };
+
+            context.Attach(goodsAttr);
+            context.Attach(selectableValue);
+
+            context.SaveChanges();
+        }
+    }
+
+    /// <summary>
+    ///     销毁
+    /// </summary>
+    [OneTimeTearDown]
+    public void TearDown()
+    {
+        foreach (var dataSource in TestCaseSourceConfigurationManager.DataSources)
+        {
+            var context = ContextUtils.CreateContext(dataSource);
+
+            //清理可能的冗余数据
+            context.CreateSet<GoodsAttribute>().Delete(p => p.AttributeId > 0 || p.GoodsId > 0);
+            context.CreateSet<SelectableValue>().Delete(p => p.AttributeId > 0 || p.CategoryId > 0);
+            context.CreateSet<StandardValue>().Delete(p => p.AttributeId > 0 || p.CategoryId > 0 || p.GoodsId > 0);
+        }
+    }
+
+    /// <summary>
+    ///     测试关联型中有重复的映射
+    /// </summary>
+    [TestCaseSource(typeof(TestCaseSourceConfigurationManager),
+        nameof(TestCaseSourceConfigurationManager.DataSourceTestCases))]
+    public void Test(EDataSource dataSource)
+    {
+        var context = ContextUtils.CreateContext(dataSource);
+        //查询GoodsAttribute
+        var goodsAttr = context.CreateSet<GoodsAttribute>().FirstOrDefault();
+        //检测值
+        Assert.That(goodsAttr, Is.Not.Null);
+        Assert.That(goodsAttr.InputValue, Is.EqualTo("测试输入值"));
+
+        //查询SelectableValue
+        var selectableValues = context.CreateSet<SelectableValue>().FirstOrDefault();
+        //检测值
+        Assert.That(selectableValues, Is.Not.Null);
+        Assert.That(selectableValues.Alias, Is.EqualTo("测试属性值"));
+        Assert.That(selectableValues.Sequence, Is.EqualTo(10));
+
+        //新增StandardValue
+        var standardValue = new StandardValue(goodsAttr, selectableValues)
+            { Alias = "某某", Photo = "1.jpg" };
+        context.Attach(standardValue);
+        context.SaveChanges();
+
+        context = ContextUtils.CreateContext(dataSource);
+
+        //查询StandardValue
+        var qstandardValue = context.CreateSet<StandardValue>().Include(p => p.GoodsAttribute)
+            .Include(p => p.SelectedValue).FirstOrDefault();
+        //检测值
+        Assert.That(qstandardValue, Is.Not.Null);
+        Assert.That(qstandardValue.Alias, Is.EqualTo("某某"));
+        Assert.That(qstandardValue.Photo, Is.EqualTo("1.jpg"));
+        Assert.That(qstandardValue.GoodsAttribute, Is.Not.Null);
+        Assert.That(qstandardValue.GoodsAttribute.InputValue, Is.EqualTo("测试输入值"));
+        Assert.That(qstandardValue.SelectedValue, Is.Not.Null);
+        Assert.That(qstandardValue.SelectedValue.Alias, Is.EqualTo("测试属性值"));
+        Assert.That(qstandardValue.SelectedValue.Sequence, Is.EqualTo(10));
+    }
+}


### PR DESCRIPTION
 - 增加完整性检查时关联引用的左端和右端名称不能相同的检查.
 - 增加完整性检查时继承关系中是否都使用相同映射表的检查.
- 修复显式关联的关联引用自动侦测左端右端时有可能设置错误的右端名的问题.
 - 修复自动建表时,重复的关联端映射导致建索引失败的问题.
- 修复某个关联型的多个关联端映射间存在重叠的映射字段时,排序字段生成的错误.
- 修改自动建表时字符串类型的字段默认映射长度为40.
- 修复一个在使用投影之后再用关联属性排序时生成的Sql语句别名错误的问题.