### PR TITLE
合并6.5.1的改动

### DIFF
--- a/ChangeLogs/6.5.1.md
+++ b/ChangeLogs/6.5.1.md
@@ -1,0 +1,9 @@
+# 6.5.1
+1. Obase.Core
+   - 为重复插入异常增加下层抛出的Sql异常作为内部异常以方便调试时确定发生异常的数据库约束.
+2. Obase.Providers.Sql
+   - 修正PGSQL中多处未正确使用限定符的问题.
+   - 修正在SqlServer中部分情况下较小的日期未正确的转换为空的问题.
+   - 修正ushort,uint, ulong类型在参数化时未正确转换为对应的数据库类型的问题.
+3. Obase.Odm.Annotation/Obase.LogicDeletion/Obase.MultiTenant/Obase.Providers.MySql/Obase.Providers.Oracle/Obase.Providers.SqlServer/Obase.Providers.Sqlite/Obase.Providers.PostgreSql
+   - 无实质更新,仅更新版本号.

--- a/Src/Obase/Directory.Build.props
+++ b/Src/Obase/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- 统一配置包版本 -->
-    <PackageVersion>6.5.0</PackageVersion>
+    <PackageVersion>6.5.1</PackageVersion>
     <!-- 统一配置输出路径 -->
     <OutputPath>../Output/</OutputPath>
     <!-- 统一配置目标框架 -->

--- a/Src/Obase/Obase.Core/Odm/Builder/ImplicitAssociationConfigor/AssociationEndConfiguration.cs
+++ b/Src/Obase/Obase.Core/Odm/Builder/ImplicitAssociationConfigor/AssociationEndConfiguration.cs
@@ -1382,11 +1382,10 @@ namespace Obase.Core.Odm.Builder.ImplicitAssociationConfigor
                 //创建关联应用配置类型 实例
                 var configuration =
                     Activator.CreateInstance(assRefCfgType, name, isMultiple, _endIndex,
-                            entityTypeConfiguration) as AssociationReferenceConfiguration
-                        <TEntity, EntityTypeConfiguration<TEntity>>;
+                            AssociationConfiguratorBuilder) as IAssociationReferenceConfigurator;
 
                 //保存
-                _associationReferenceConfiguration = configuration ??
+                _associationReferenceConfiguration = (AssociationReferenceConfiguration<TEntity>)configuration ??
                                                      throw new ArgumentException(
                                                          $"创建类型为{typeof(TEntity)}.{name}关联引用配置类型失败");
                 _referenceConfigurator = configuration;

--- a/Src/Obase/Obase.Core/Saving/ConcurrentConflictException.cs
+++ b/Src/Obase/Obase.Core/Saving/ConcurrentConflictException.cs
@@ -32,7 +32,8 @@ namespace Obase.Core.Saving
         /// </summary>
         /// <param name="obj">发生并发冲突的对象。</param>
         /// <param name="objType">发生并发冲突的对象的类型。</param>
-        protected ConcurrentConflictException(object obj, ObjectType objType)
+        /// <param name="exception">内部异常</param>
+        protected ConcurrentConflictException(object obj, ObjectType objType, Exception exception) : base("发生了并发冲突", exception)
         {
             _object = obj;
             _objectType = objType;

--- a/Src/Obase/Obase.Core/Saving/ConcurrentConflictHandlerFactory.cs
+++ b/Src/Obase/Obase.Core/Saving/ConcurrentConflictHandlerFactory.cs
@@ -38,6 +38,11 @@ namespace Obase.Core.Saving
         private IStorageProvider _storageProvider;
 
         /// <summary>
+        ///     内部异常
+        /// </summary>
+        private Exception _innerException;
+
+        /// <summary>
         ///     获取或设置对象数据模型。
         /// </summary>
         public ObjectDataModel Model
@@ -71,6 +76,15 @@ namespace Obase.Core.Saving
         {
             get => _storageProvider;
             set => _storageProvider = value;
+        }
+
+        /// <summary>
+        ///     内部异常
+        /// </summary>
+        public Exception InnerException
+        {
+            get => _innerException;
+            set => _innerException = value;
         }
 
         /// <summary>

--- a/Src/Obase/Obase.Core/Saving/RepeatCreationException.cs
+++ b/Src/Obase/Obase.Core/Saving/RepeatCreationException.cs
@@ -7,6 +7,7 @@
 └──────────────────────────────────────────────────────────────┘
 */
 
+using System;
 using Obase.Core.Odm;
 
 namespace Obase.Core.Saving
@@ -21,7 +22,8 @@ namespace Obase.Core.Saving
         /// </summary>
         /// <param name="obj">发生冲突的对象。</param>
         /// <param name="objType">发生冲突的对象的类型。</param>
-        public RepeatCreationException(object obj, ObjectType objType) : base(obj, objType)
+        /// <param name="exception">内部异常</param>
+        public RepeatCreationException(object obj, ObjectType objType, Exception exception) : base(obj, objType, exception)
         {
         }
 

--- a/Src/Obase/Obase.Core/Saving/RepeatInsertionException.cs
+++ b/Src/Obase/Obase.Core/Saving/RepeatInsertionException.cs
@@ -29,7 +29,9 @@ namespace Obase.Core.Saving
         /// <summary>
         ///     创建RepeatInsertionException实例。
         /// </summary>
-        public RepeatInsertionException(bool isUnSupported) : base("插入了重复的记录。")
+        /// <param name="isUnSupported">当前数据源是否不支持此异常的处理模式</param>
+        /// <param name="exception">内部异常</param>
+        public RepeatInsertionException(bool isUnSupported, Exception exception) : base("插入了重复的记录。", exception)
         {
             _isUnSupported = isUnSupported;
         }

--- a/Src/Obase/Obase.Core/Saving/SavingProvider.cs
+++ b/Src/Obase/Obase.Core/Saving/SavingProvider.cs
@@ -827,6 +827,7 @@ namespace Obase.Core.Saving
                             //给工厂设值
                             factory.Model = _model;
                             factory.StorageProvider = provider;
+                            factory.InnerException = ex;
 
                             //处理此次冲突
                             var handler = factory.CreateRepeatCreationHandler();

--- a/Src/Obase/Obase.Core/Saving/ThrowExceptionConflictHandler.cs
+++ b/Src/Obase/Obase.Core/Saving/ThrowExceptionConflictHandler.cs
@@ -20,6 +20,11 @@ namespace Obase.Core.Saving
         IVersionConflictHandler, IUpdatingPhantomHandler
     {
         /// <summary>
+        ///     由下层抛出的异常
+        /// </summary>
+        private readonly Exception _innerException;
+
+        /// <summary>
         ///     用于获取属性原值的委托。
         /// </summary>
         private readonly GetAttributeValue _attributeOriginalValueGetter;
@@ -28,10 +33,12 @@ namespace Obase.Core.Saving
         ///     创建ThrowException-ConflictHandler实例。
         /// </summary>
         /// <param name="model">对象数据模型。</param>
+        /// <param name="innerException">内部异常</param>
         /// <param name="attributeOriginalValueGetter">用于获取属性原值的委托。</param>
-        public ThrowExceptionConflictHandler(ObjectDataModel model,
+        public ThrowExceptionConflictHandler(ObjectDataModel model,Exception innerException,
             GetAttributeValue attributeOriginalValueGetter = null) : base(model)
         {
+            _innerException = innerException;
             _attributeOriginalValueGetter = attributeOriginalValueGetter;
         }
 
@@ -77,10 +84,10 @@ namespace Obase.Core.Saving
             switch (conflictType)
             {
                 case EConcurrentConflictType.RepeatCreation:
-                    ex = new RepeatCreationException(obj, objType);
+                    ex = new RepeatCreationException(obj, objType, _innerException);
                     break;
                 case EConcurrentConflictType.UpdatingPhantom:
-                    ex = new UpdatingPhantomException(obj, objType);
+                    ex = new UpdatingPhantomException(obj, objType, _innerException);
                     break;
                 case EConcurrentConflictType.VersionConflict:
                     //没有版本键 发生版本冲突异常不能表示实际的情况 暂且忽略
@@ -115,7 +122,7 @@ namespace Obase.Core.Saving
                         keys.Add(new ObjectKey(itemType, members));
                     }
 
-                    ex = new VersionConflictException(obj, objType, keys);
+                    ex = new VersionConflictException(obj, objType, keys, _innerException);
                     break;
                 default:
                     ex = new ArgumentOutOfRangeException(nameof(conflictType), conflictType,

--- a/Src/Obase/Obase.Core/Saving/ThrowExceptionConflictHandlerFactory.cs
+++ b/Src/Obase/Obase.Core/Saving/ThrowExceptionConflictHandlerFactory.cs
@@ -19,7 +19,7 @@ namespace Obase.Core.Saving
         /// </summary>
         public override IRepeatCreationHandler CreateRepeatCreationHandler()
         {
-            var throwExceptionConflictHandler = new ThrowExceptionConflictHandler(Model, AttributeOriginalValueGetter);
+            var throwExceptionConflictHandler = new ThrowExceptionConflictHandler(Model, InnerException, AttributeOriginalValueGetter);
             return throwExceptionConflictHandler;
         }
 
@@ -28,7 +28,7 @@ namespace Obase.Core.Saving
         /// </summary>
         public override IVersionConflictHandler CreateVersionConflictHandler()
         {
-            var throwExceptionConflictHandler = new ThrowExceptionConflictHandler(Model, AttributeOriginalValueGetter);
+            var throwExceptionConflictHandler = new ThrowExceptionConflictHandler(Model, InnerException, AttributeOriginalValueGetter);
             return throwExceptionConflictHandler;
         }
 
@@ -37,7 +37,7 @@ namespace Obase.Core.Saving
         /// </summary>
         public override IUpdatingPhantomHandler CreateUpdatingPhantomHandler()
         {
-            var throwExceptionConflictHandler = new ThrowExceptionConflictHandler(Model, AttributeOriginalValueGetter);
+            var throwExceptionConflictHandler = new ThrowExceptionConflictHandler(Model, InnerException, AttributeOriginalValueGetter);
             return throwExceptionConflictHandler;
         }
     }

--- a/Src/Obase/Obase.Core/Saving/UnSupportedException.cs
+++ b/Src/Obase/Obase.Core/Saving/UnSupportedException.cs
@@ -28,7 +28,7 @@ namespace Obase.Core.Saving
         /// <param name="objType">发生并发冲突的对象的类型。</param>
         /// <param name="repeatInsertionException">内部异常</param>
         public UnSupportedException(object obj, ObjectType objType, RepeatInsertionException repeatInsertionException) :
-            base(obj, objType)
+            base(obj, objType, repeatInsertionException)
         {
             _repeatInsertionException = repeatInsertionException;
         }

--- a/Src/Obase/Obase.Core/Saving/UpdatingPhantomException.cs
+++ b/Src/Obase/Obase.Core/Saving/UpdatingPhantomException.cs
@@ -7,6 +7,7 @@
 └──────────────────────────────────────────────────────────────┘
 */
 
+using System;
 using Obase.Core.Odm;
 
 namespace Obase.Core.Saving
@@ -21,7 +22,8 @@ namespace Obase.Core.Saving
         /// </summary>
         /// <param name="obj">发生冲突的对象。</param>
         /// <param name="objType">发生冲突的对象的类型。</param>
-        public UpdatingPhantomException(object obj, ObjectType objType) : base(obj, objType)
+        /// <param name="exception">内部异常</param>
+        public UpdatingPhantomException(object obj, ObjectType objType, Exception exception) : base(obj, objType, exception)
         {
         }
 

--- a/Src/Obase/Obase.Core/Saving/VersionConflictException.cs
+++ b/Src/Obase/Obase.Core/Saving/VersionConflictException.cs
@@ -7,6 +7,7 @@
 └──────────────────────────────────────────────────────────────┘
 */
 
+using System;
 using System.Collections.Generic;
 using Obase.Core.Odm;
 
@@ -28,8 +29,9 @@ namespace Obase.Core.Saving
         /// <param name="obj">发生冲突的对象。</param>
         /// <param name="objType">发生冲突的对象的类型。</param>
         /// <param name="initVersionKeys">发生冲突的各个对象（主对象和伴随映射对象）的初始版本标识。</param>
-        public VersionConflictException(object obj, ObjectType objType, List<ObjectKey> initVersionKeys) : base(obj,
-            objType)
+        /// <param name="exception">内部异常</param>
+        public VersionConflictException(object obj, ObjectType objType, List<ObjectKey> initVersionKeys, Exception exception) : base(obj,
+            objType, exception)
         {
             _initialVersionKeys = initVersionKeys;
         }

--- a/Src/Obase/Obase.Core/SubTreeEvaluator.cs
+++ b/Src/Obase/Obase.Core/SubTreeEvaluator.cs
@@ -7,6 +7,7 @@
 └──────────────────────────────────────────────────────────────┘
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
@@ -48,8 +49,15 @@ namespace Obase.Core
             //编译 求值 组成静态表达式
             var lambda = Expression.Lambda(subTree);
             var fn = lambda.Compile();
-            var value = fn.DynamicInvoke(null);
-            return Expression.Constant(value, subTree.Type);
+            try
+            {
+                var value = fn.DynamicInvoke(null);
+                return Expression.Constant(value, subTree.Type);
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("求值失败,请参考内部异常信息调整表达式.", e);
+            }
         }
 
         /// <summary>

--- a/Src/Obase/Obase.LogicDeletion/README.md
+++ b/Src/Obase/Obase.LogicDeletion/README.md
@@ -1,4 +1,4 @@
-## Obase.LogicDeletion
-±¾ÏîÄ¿ÎªObaseµÄÂß¼­É¾³ı²å¼ş,Ìá¹©ÁËÂß¼­É¾³ıµÄ¹¦ÄÜºÍÏà¹ØÊµÏÖ.
+ï»¿## Obase.LogicDeletion
+æœ¬é¡¹ç›®ä¸ºObaseçš„é€»è¾‘åˆ é™¤æ’ä»¶,æä¾›äº†é€»è¾‘åˆ é™¤çš„åŠŸèƒ½å’Œç›¸å…³å®ç°.
 
-ÏîÄ¿¿ªÔ´ÓÚ[GitHub](https://github.com/lechengruangong/Obase4DotNet).
+é¡¹ç›®å¼€æºäº[GitHub](https://github.com/lechengruangong/Obase4DotNet).

--- a/Src/Obase/Obase.Providers.Sql/ExistingConnectionSqlExecutor.cs
+++ b/Src/Obase/Obase.Providers.Sql/ExistingConnectionSqlExecutor.cs
@@ -158,7 +158,7 @@ namespace Obase.Providers.Sql
                 //发生异常 是否为主键重复插入异常
                 if (IsRepeatInsertionError(ex))
                 {
-                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql);
+                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql, ex);
                     if (SourceType == EDataSource.PostgreSql)
                         ex1.UnSupportMessage = "PostgreSQL不支持在单一事务块中发生异常后再次执行其他命令.";
                     throw ex1;
@@ -201,7 +201,7 @@ namespace Obase.Providers.Sql
                 //发生异常 是否为主键重复插入异常
                 if (IsRepeatInsertionError(ex))
                 {
-                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql);
+                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql, ex);
                     if (SourceType == EDataSource.PostgreSql)
                         ex1.UnSupportMessage = "PostgreSQL不支持在单一事务块中发生异常后再次执行其他命令.";
                     throw ex1;

--- a/Src/Obase/Obase.Providers.Sql/SqlExecutor.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlExecutor.cs
@@ -311,7 +311,7 @@ namespace Obase.Providers.Sql
                 //发生异常 是否为主键重复插入异常
                 if (IsRepeatInsertionError(ex))
                 {
-                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql);
+                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql, ex);
                     if (SourceType == EDataSource.PostgreSql)
                         ex1.UnSupportMessage = "PostgreSQL不支持在单一事务块中发生异常后再次执行其他命令.";
                     throw ex1;
@@ -410,7 +410,7 @@ namespace Obase.Providers.Sql
                 //发生异常 是否为主键重复插入异常
                 if (IsRepeatInsertionError(ex))
                 {
-                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql);
+                    var ex1 = new RepeatInsertionException(SourceType == EDataSource.PostgreSql, ex);
                     if (SourceType == EDataSource.PostgreSql)
                         ex1.UnSupportMessage = "PostgreSQL不支持在单一事务块中发生异常后再次执行其他命令.";
                     throw ex1;

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/BoolFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/BoolFieldSetter.cs
@@ -180,8 +180,8 @@ namespace Obase.Providers.Sql.SqlObject
             //非空 加入参数
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
+            if (!aNull) parameters.Value = DBNull.Value;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
-            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
 
             return parameter;
         }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/ChangeSql.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/ChangeSql.cs
@@ -497,7 +497,7 @@ namespace Obase.Providers.Sql.SqlObject
                     reultBuilder = new StringBuilder($" UPDATE [{tSource.Symbol}] ");
                     break;
                 case EDataSource.PostgreSql:
-                    reultBuilder = new StringBuilder("UPDATE \"" + tSource.Symbol + "\"" + tSource.Symbol);
+                    reultBuilder = new StringBuilder("UPDATE \"" + tSource.Symbol + "\" \"" + tSource.Symbol + "\"");
                     break;
                 //Oracle数据源
                 case EDataSource.Oracle:
@@ -635,7 +635,7 @@ namespace Obase.Providers.Sql.SqlObject
                     /*From 查询源*/
                     resultBuilder.Append($" FROM {simpleSource.ToNoSymbolString(sourceType)} ");
                     if (sourceType == EDataSource.PostgreSql)
-                        resultBuilder.Append(" ").Append(simpleSource.Name).Append(" ");
+                        resultBuilder.Append(" \"").Append(simpleSource.Name).Append("\" ");
                 }
             }
             else

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/ComparisonExpression.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/ComparisonExpression.cs
@@ -103,10 +103,39 @@ namespace Obase.Providers.Sql.SqlObject
             var isLeftNull = false;
             var isRightNull = false;
             //比较表达式可能为空 为空时特殊翻译
-            if (Left is ConstantExpression leftConstantExpression && leftConstantExpression.Value == null)
-                isLeftNull = true;
-            if (Right is ConstantExpression rightConstantExpression && rightConstantExpression.Value == null)
-                isRightNull = true;
+            if (Left is ConstantExpression leftConstantExpression)
+            {
+                //如果直接就是空 判定为空
+                if (leftConstantExpression.Value == null)
+                {
+                    isLeftNull = true;
+                }
+                //如果是SqlServer数据源，则需要判断日期时间是否在SqlServer的支持范围内，如果不在范围内，则返回null
+                if (sourceType == EDataSource.SqlServer && leftConstantExpression.Value is DateTime dateTime)
+                {
+                    if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
+                        isLeftNull = false;
+                    else
+                        isLeftNull = true;
+                }
+            }
+
+            if (Right is ConstantExpression rightConstantExpression)
+            {
+                //如果直接就是空 判定为空
+                if (rightConstantExpression.Value == null)
+                {
+                    isRightNull = true;
+                }
+                //如果是SqlServer数据源，则需要判断日期时间是否在SqlServer的支持范围内，如果不在范围内，则返回null
+                if (sourceType == EDataSource.SqlServer && rightConstantExpression.Value is DateTime dateTime)
+                {
+                    if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
+                        isRightNull = false;
+                    else
+                        isRightNull = true;
+                }
+            }
 
             //结果 左侧表达式参数
             string result;

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/DateTimeFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/DateTimeFieldSetter.cs
@@ -54,9 +54,15 @@ namespace Obase.Providers.Sql.SqlObject
         {
             var dateTime = (DateTime)Convert.ChangeType(Value, typeof(DateTime));
 
-            if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
-                return $"{_field.ToString(sourceType)} ='{_value:yyyy-MM-dd HH:mm:ss.fff}'";
-            return $"{_field.ToString(sourceType)}=null ";
+            // 如果是SqlServer数据源，则需要判断日期时间是否在SqlServer的支持范围内，如果不在范围内，则返回null
+            if (sourceType == EDataSource.SqlServer)
+            {
+                if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
+                    return $"{_field.ToString(sourceType)} ='{_value:yyyy-MM-dd HH:mm:ss.fff}'";
+                return $"{_field.ToString(sourceType)}=null ";
+            }
+
+            return $"{_field.ToString(sourceType)} ='{_value:yyyy-MM-dd HH:mm:ss.fff}'";
         }
 
 
@@ -80,10 +86,16 @@ namespace Obase.Providers.Sql.SqlObject
         {
             var dateTime = (DateTime)Convert.ChangeType(Value, typeof(DateTime));
             field = GetFiledString(sourceType);
-            if (_value >= Convert.ToDateTime("1753/1/1") && _value <= Convert.ToDateTime("9999/12/31"))
-                return dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
 
-            return "null";
+            // 如果是SqlServer数据源，则需要判断日期时间是否在SqlServer的支持范围内，如果不在范围内，则返回null
+            if (sourceType == EDataSource.SqlServer)
+            {
+                if (_value >= Convert.ToDateTime("1753/1/1") && _value <= Convert.ToDateTime("9999/12/31"))
+                    return dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
+
+                return "null";
+            }
+            return dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
         }
 
         /// <summary>
@@ -109,11 +121,20 @@ namespace Obase.Providers.Sql.SqlObject
         {
             var dateTime = (DateTime)Convert.ChangeType(Value, typeof(DateTime));
             string valueStr;
-            if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
-                valueStr = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
-            else
-                valueStr = "null";
 
+            // 如果是SqlServer数据源，则需要判断日期时间是否在SqlServer的支持范围内，如果不在范围内，则返回null
+            if (sourceType == EDataSource.SqlServer)
+            {
+                if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
+                    valueStr = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
+                else
+                    valueStr = "null";
+            }
+            else
+            {
+                valueStr = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            }
+            
             var parameter = GetParameters(out parameters, sourceType, valueStr, creator);
 
             return $"{_field.ToString(sourceType)} = {parameter}";
@@ -148,11 +169,20 @@ namespace Obase.Providers.Sql.SqlObject
 
             var dateTime = (DateTime)Convert.ChangeType(Value, typeof(DateTime));
             string valueStr;
-            if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
-                valueStr = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
-            else
-                valueStr = "null";
 
+            // 如果是SqlServer数据源，则需要判断日期时间是否在SqlServer的支持范围内，如果不在范围内，则返回null
+            if (sourceType == EDataSource.SqlServer)
+            {
+                if (dateTime >= Convert.ToDateTime("1753/1/1") && dateTime <= Convert.ToDateTime("9999/12/31"))
+                    valueStr = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
+                else
+                    valueStr = "null";
+            }
+            else
+            {
+                valueStr = dateTime.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            }
+            
             return GetParameters(out parameters, sourceType, valueStr, creator);
         }
 

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/DateTimeFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/DateTimeFieldSetter.cs
@@ -198,8 +198,9 @@ namespace Obase.Providers.Sql.SqlObject
             //非空 加入参数
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
+            if (!aNull) parameters.Value = DBNull.Value;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
-            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
+            
             return parameter;
         }
     }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/ExpressionColumn.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/ExpressionColumn.cs
@@ -8,6 +8,7 @@
 */
 
 using Obase.Providers.Sql.Rop;
+using System.Xml.Linq;
 
 namespace Obase.Providers.Sql.SqlObject
 {
@@ -87,6 +88,16 @@ namespace Obase.Providers.Sql.SqlObject
         /// <returns></returns>
         public override string ToString(EDataSource sourceType)
         {
+            //对于PostgreSql 别名需要加双引号 否则会被转换为小写
+            if (sourceType == EDataSource.PostgreSql && !string.IsNullOrEmpty(_alias))
+            {
+                if (_alias.StartsWith("OTB") || _alias.StartsWith("otb"))
+                    //当使用OTB生成时 此处的字段不应使用限定符
+                    return $"{_expression.ToString(sourceType)} {_alias}";
+
+                return $"{_expression.ToString(sourceType)} \"{_alias}\"";
+            }
+                
             return $"{_expression.ToString(sourceType)} {_alias}";
         }
 

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/ExpressionColumn.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/ExpressionColumn.cs
@@ -8,7 +8,6 @@
 */
 
 using Obase.Providers.Sql.Rop;
-using System.Xml.Linq;
 
 namespace Obase.Providers.Sql.SqlObject
 {
@@ -97,7 +96,7 @@ namespace Obase.Providers.Sql.SqlObject
 
                 return $"{_expression.ToString(sourceType)} \"{_alias}\"";
             }
-                
+
             return $"{_expression.ToString(sourceType)} {_alias}";
         }
 

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/Field.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/Field.cs
@@ -106,9 +106,9 @@ namespace Obase.Providers.Sql.SqlObject
                     {
                         if (_name.Contains("OTB"))
                             //当使用OTB生成时 此处的字段不应使用限定符
-                            return $"{Source.Symbol}.{_name}";
+                            return $"\"{Source.Symbol}\".{_name}";
 
-                        return $"{Source.Symbol}.\"{_name}\"";
+                        return $"\"{Source.Symbol}\".\"{_name}\"";
                     }
 
                     return $"\"{_name}\"";

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/Field.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/Field.cs
@@ -104,7 +104,7 @@ namespace Obase.Providers.Sql.SqlObject
                 {
                     if (Source != null && Source.Symbol != null && !string.IsNullOrEmpty(Source.Symbol))
                     {
-                        if (_name.Contains("OTB"))
+                        if (_name.StartsWith("OTB") || _name.StartsWith("otb"))
                             //当使用OTB生成时 此处的字段不应使用限定符
                             return $"\"{Source.Symbol}\".{_name}";
 

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/NumericFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/NumericFieldSetter.cs
@@ -178,12 +178,12 @@ namespace Obase.Providers.Sql.SqlObject
             //非空 加入参数
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
+            if (!aNull) parameters.Value = DBNull.Value;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
-            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
-            //如果是SqlServer ushrot uint ulong需要转换为有符号的类型
-            if (sourceType == EDataSource.SqlServer)
-                if (valueStr is ushort || valueStr is uint || valueStr is ulong)
-                    parameters.Value = Convert.ToInt64(valueStr);
+            //如果是SqlServer或者PostgreSql ushrot uint ulong需要转换为有符号的类型
+            if (sourceType == EDataSource.SqlServer || sourceType == EDataSource.PostgreSql)
+                if (Value is ushort || Value is uint || Value is ulong)
+                    parameters.Value = Convert.ToInt64(Value);
             return parameter;
         }
     }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/SelectSource.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/SelectSource.cs
@@ -157,7 +157,7 @@ namespace Obase.Providers.Sql.SqlObject
                 case EDataSource.PostgreSql:
                 case EDataSource.Oracle:
                 {
-                    return $"({QuerySql.ToSql(sourceType, out sqlParameters, creator)}) {Symbol}";
+                    return $"({QuerySql.ToSql(sourceType, out sqlParameters, creator)}) \"{Symbol}\"";
                 }
                 case EDataSource.MySql:
                 case EDataSource.Sqlite:

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/SimpleCriteria.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/SimpleCriteria.cs
@@ -186,8 +186,9 @@ namespace Obase.Providers.Sql.SqlObject
         /// <summary>
         ///     生成value对应数据中的值
         /// </summary>
+        /// <param name="sourceType">数据源类型</param>
         /// <returns></returns>
-        protected virtual string GenerateSqlValue()
+        protected virtual string GenerateSqlValue(EDataSource sourceType)
         {
             string matchValue;
             if (Value == null) return null;
@@ -196,24 +197,34 @@ namespace Obase.Providers.Sql.SqlObject
             {
                 //处理日期
                 var date = Convert.ToDateTime(Value);
-                if (date < DateTime.Parse("1753/01/01"))
+
+                //如果是SqlServer数据源，则需要判断日期时间是否在SqlServer的支持范围内，如果不在范围内，则返回null
+                if (sourceType == EDataSource.SqlServer)
                 {
-                    if (Operator == ERelationOperator.Equal || Operator == ERelationOperator.Unequal)
-                        matchValue = null;
+                    if (date < DateTime.Parse("1753/1/1"))
+                    {
+                        if (Operator == ERelationOperator.Equal || Operator == ERelationOperator.Unequal)
+                            matchValue = null;
+                        else
+                            matchValue = "'1753/01/01'";
+                    }
+                    else if (date > DateTime.Parse("9999/12/31"))
+                    {
+                        if (Operator == ERelationOperator.Equal || Operator == ERelationOperator.Unequal)
+                            matchValue = null;
+                        else
+                            matchValue = "'9999/12/31'";
+                    }
                     else
-                        matchValue = "'1753/01/01'";
-                }
-                else if (date > DateTime.Parse("9999/12/31"))
-                {
-                    if (Operator == ERelationOperator.Equal || Operator == ERelationOperator.Unequal)
-                        matchValue = null;
-                    else
-                        matchValue = "'9999/12/31'";
+                    {
+                        matchValue = "'" + date.ToString("yyyy-MM-dd HH:mm:ss.fff") + "'";
+                    }
                 }
                 else
                 {
                     matchValue = "'" + date.ToString("yyyy-MM-dd HH:mm:ss.fff") + "'";
                 }
+                
             }
             //处理时间
             else if (Value is TimeSpan time)
@@ -321,7 +332,7 @@ namespace Obase.Providers.Sql.SqlObject
             //字段
             var result = Field.ToString(sourceType);
             //值
-            var matchValue = GenerateSqlValue();
+            var matchValue = GenerateSqlValue(sourceType);
             switch (Operator)
             {
                 case ERelationOperator.Equal:

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/SimpleSource.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/SimpleSource.cs
@@ -120,7 +120,7 @@ namespace Obase.Providers.Sql.SqlObject
                     }
                     case EDataSource.PostgreSql:
                     {
-                        return $"\"{_name}\" {Symbol}";
+                        return $"\"{_name}\" \"{Symbol}\"";
                     }
                     case EDataSource.Oracle:
                     {
@@ -149,7 +149,7 @@ namespace Obase.Providers.Sql.SqlObject
                 }
                 case EDataSource.PostgreSql:
                 {
-                    return $"{_name}";
+                    return $"\"{_name}\"";
                 }
                 case EDataSource.Oracle:
                 {

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/TimeSpanFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/TimeSpanFieldSetter.cs
@@ -175,8 +175,8 @@ namespace Obase.Providers.Sql.SqlObject
             //非空 加入参数
             var aNull = !valueStr.ToString().Trim().Equals("null");
             parameters.Value = aNull ? valueStr : null;
+            if (!aNull) parameters.Value = DBNull.Value;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
-            if (sourceType == EDataSource.SqlServer && !aNull) parameters.Value = DBNull.Value;
 
             return parameter;
         }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/TimeSpanFieldSetter.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/TimeSpanFieldSetter.cs
@@ -177,6 +177,7 @@ namespace Obase.Providers.Sql.SqlObject
             parameters.Value = aNull ? valueStr : null;
             if (!aNull) parameters.Value = DBNull.Value;
             if (sourceType == EDataSource.PostgreSql && aNull) parameters.Value = Value;
+            
 
             return parameter;
         }

--- a/Src/Obase/Obase.Providers.Sql/SqlObject/WildcardColumn.cs
+++ b/Src/Obase/Obase.Providers.Sql/SqlObject/WildcardColumn.cs
@@ -80,7 +80,7 @@ namespace Obase.Providers.Sql.SqlObject
                 case EDataSource.SqlServer:
                     return $"[{_source.Symbol}].*";
                 case EDataSource.PostgreSql:
-                    return $"{_source.Symbol}.*";
+                    return $"\"{_source.Symbol}\".*";
                 case EDataSource.Oracle:
                     return $"{_source.Symbol}.*";
                 case EDataSource.Oledb:

--- a/Src/UnitTest/Obase.Test.Domain/Functional/KeyWords/Order.cs
+++ b/Src/UnitTest/Obase.Test.Domain/Functional/KeyWords/Order.cs
@@ -1,0 +1,32 @@
+﻿namespace Obase.Test.Domain.Functional.KeyWords;
+
+/// <summary>
+///     Order关键字的同名类
+/// </summary>
+public class Order
+{
+    /// <summary>
+    ///     主键
+    /// </summary>
+    public string Code { get; set; }
+
+    /// <summary>
+    ///     名称
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    ///     包装度
+    /// </summary>
+    public ushort Pack { get; set; }
+
+    /// <summary>
+    ///     用户ID
+    /// </summary>
+    public long UserId { get; set; }
+
+    /// <summary>
+    ///     用户
+    /// </summary>
+    public User User { get; set; }
+}

--- a/Src/UnitTest/Obase.Test.Domain/Functional/KeyWords/User.cs
+++ b/Src/UnitTest/Obase.Test.Domain/Functional/KeyWords/User.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace Obase.Test.Domain.Functional.KeyWords;
+
+/// <summary>
+///     USER关键字同名类
+/// </summary>
+public class User
+{
+    /// <summary>
+    ///     主键
+    /// </summary>
+    public long UserId { get; set; }
+
+    /// <summary>
+    ///     名称
+    /// </summary>
+    public string UserName { get; set; }
+
+    /// <summary>
+    ///     订单
+    /// </summary>
+    public List<Order> Orders { get; set; }
+}

--- a/Src/UnitTest/Obase.Test.Infrastructure/ModelRegister/CoreModelRegister.cs
+++ b/Src/UnitTest/Obase.Test.Infrastructure/ModelRegister/CoreModelRegister.cs
@@ -1363,5 +1363,13 @@ public static class CoreModelRegister
         //Component有引用 无需配置 自动侦测
 
         #endregion
+
+        //对应测试文件CoreTest/FunctionalTest文件夹内KeyWordsTest
+
+        #region 与关键字同名的表
+
+        //配置与关键字同名的表的实体型 符合推断 无需注册
+
+        #endregion
     }
 }

--- a/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/AssociationQueryTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/AssociationTest/AssociationQueryTest.cs
@@ -324,6 +324,13 @@ public class AssociationQueryTest
 
         Assert.That(classes.Count, Is.EqualTo(1));
 
+        //根据显式关联型引用的关联端的属性排序
+        var classTeachers = context.CreateSet<ClassTeacher>().Include(p => p.Class).Include(p => p.Teacher)
+            .Where(p => p.Class.Name != "123")
+            .OrderBy(p => p.Class.Name).Skip(0).Take(1).ToList();
+
+        Assert.That(classTeachers.Count, Is.EqualTo(1));
+
         //投影之后 使用学生名称 和 学生关联的班级关联的学校创建时间排序
         var oStud = context.CreateSet<Class>().SelectMany(p => p.Students)
             .OrderBy(p => p.Name).ThenBy(p => p.Class.School.Createtime).ToList();

--- a/Src/UnitTest/Obase.Test/CoreTest/FunctionalTest/DataErrorTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/FunctionalTest/DataErrorTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Obase.Core;
 using Obase.Providers.Sql;
 using Obase.Test.Configuration;
@@ -75,7 +76,7 @@ public class DataErrorTest
         var context = ContextUtils.CreateContext(dataSource);
         //加载一对一关联
         var student = context.CreateSet<DataErrorStudent>().Include(p => p.StudentInfo).FirstOrDefault();
-        //此时军不为空
+        //此时不为空
         Assert.That(student, Is.Not.Null);
         Assert.That(student.StudentInfo, Is.Not.Null);
         //随意修改一个属性
@@ -87,5 +88,17 @@ public class DataErrorTest
         var count = context.CreateSet<DataErrorStudentInfo>().Count(p => p.StudentId == 1);
         //仍然有两个
         Assert.That(count, Is.EqualTo(2));
+
+        //使用无法转换的字符串进行查询
+        const string str = "a-b-c";
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+           
+            context = ContextUtils.CreateContext(dataSource);
+            //查询学生
+            student = context.CreateSet<DataErrorStudent>().Include(p => p.StudentInfo)
+                .FirstOrDefault(p => p.StudentId == Convert.ToInt64(str));
+        }, "求值失败,请参考内部异常信息调整表达式.");
     }
 }

--- a/Src/UnitTest/Obase.Test/CoreTest/FunctionalTest/KeyWordsTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/FunctionalTest/KeyWordsTest.cs
@@ -1,0 +1,92 @@
+﻿using System.Linq;
+using Obase.Core;
+using Obase.Providers.Sql;
+using Obase.Test.Configuration;
+using Obase.Test.Domain.Functional.KeyWords;
+
+namespace Obase.Test.CoreTest.FunctionalTest;
+
+/// <summary>
+///     关键字同名类测试类
+/// </summary>
+[TestFixture]
+public class KeyWordsTest
+{
+    /// <summary>
+    ///     构造实例 为上下文赋值
+    /// </summary>
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        foreach (var dataSource in TestCaseSourceConfigurationManager.DataSources)
+        {
+            var context = ContextUtils.CreateContext(dataSource);
+            //清理
+            context.CreateSet<User>().Delete(p => p.UserId > 0);
+            context.CreateSet<Order>().Delete(p => p.Code != "");
+
+            //插入数据
+            var user = new User
+            {
+                UserName = "张三"
+            };
+
+            var order1 = new Order
+            {
+                Code = "001",
+                Name = "订单1",
+                User = user,
+                Pack = 1
+            };
+
+            var order2 = new Order
+            {
+                Code = "002",
+                Name = "订单2",
+                User = user,
+                Pack = 2
+            };
+            //附加
+            context.Attach(user);
+            context.Attach(order1);
+            context.Attach(order2);
+            //保存
+            context.SaveChanges();
+        }
+    }
+
+
+    /// <summary>
+    ///     销毁对象
+    /// </summary>
+    [OneTimeTearDown]
+    public void Dispose()
+    {
+        foreach (var dataSource in TestCaseSourceConfigurationManager.DataSources)
+        {
+            var context = ContextUtils.CreateContext(dataSource);
+            //清理
+            context.CreateSet<User>().Delete(p => p.UserId > 0);
+            context.CreateSet<Order>().Delete(p => p.Code != "");
+        }
+    }
+
+    /// <summary>
+    ///     测试方法
+    /// </summary>
+    [TestCaseSource(typeof(TestCaseSourceConfigurationManager),
+        nameof(TestCaseSourceConfigurationManager.DataSourceTestCases))]
+    public void Test(EDataSource dataSource)
+    {
+        //构造上下文
+        var context = ContextUtils.CreateContext(dataSource);
+
+        var user = context.CreateSet<User>().Include(p => p.Orders).FirstOrDefault(p => p.UserName == "张三");
+        //验证
+        Assert.That(user, Is.Not.Null);
+        Assert.That(user.Orders, Is.Not.Null);
+        Assert.That(user.Orders.Count, Is.EqualTo(2));
+        Assert.That(user.Orders[0].Pack, Is.EqualTo(1));
+        Assert.That(user.Orders[1].Pack, Is.EqualTo(2));
+    }
+}

--- a/Src/UnitTest/Obase.Test/CoreTest/SimpleTypeTest/SimpleTypeEnumerableTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/SimpleTypeTest/SimpleTypeEnumerableTest.cs
@@ -45,7 +45,6 @@ public class SimpleTypeEnumerableTest
                     FloatNumber = (float)Math.Pow(Math.PI, i),
                     DoubleNumber = (float)Math.Pow(Math.PI, i),
                     Time = new TimeSpan(0, 8, 40, 0),
-                    Date = DateTime.Now,
                     String = $"{i}号字符串",
                     Strings = new[] { $"{i - 1}", $"{i}", $"{i + 1}" }
                 });

--- a/Src/UnitTest/Obase.Test/CoreTest/SimpleTypeTest/SimpleTypeEnumerableTest.cs
+++ b/Src/UnitTest/Obase.Test/CoreTest/SimpleTypeTest/SimpleTypeEnumerableTest.cs
@@ -633,7 +633,7 @@ public class SimpleTypeEnumerableTest
         //存在 不为空
         Assert.That(singelResult, Is.Not.Null);
         //单值 有默认值 但有多个满足条件的 //会直接报错
-        Assert.Throws<InvalidOperationException>(() => context.CreateSet<JavaBean>().SingleOrDefault());
+        Assert.Throws<InvalidOperationException>(() => { context.CreateSet<JavaBean>().SingleOrDefault(); });
     }
 
     /// <summary>
@@ -754,6 +754,11 @@ public class SimpleTypeEnumerableTest
 
         //测试查询时间
         whereResult = context.CreateSet<JavaBean>().Where(p => p.DateTime < DateTime.Now).ToList();
+        //有20个对象满足条件
+        Assert.That(whereResult.Count, Is.EqualTo(20));
+
+        //测试DateTime默认值
+        whereResult = context.CreateSet<JavaBean>().Where(p => p.Date == DateTime.MinValue).ToList();
         //有20个对象满足条件
         Assert.That(whereResult.Count, Is.EqualTo(20));
 


### PR DESCRIPTION
# 6.5.1
1. Obase.Core
   - 为重复插入异常增加下层抛出的Sql异常作为内部异常以方便调试时确定发生异常的数据库约束.
2. Obase.Providers.Sql
   - 修正PGSQL中多处未正确使用限定符的问题.
   - 修正在SqlServer中部分情况下较小的日期未正确的转换为空的问题.
   - 修正ushort,uint, ulong类型在参数化时未正确转换为对应的数据库类型的问题.
3. Obase.Odm.Annotation/Obase.LogicDeletion/Obase.MultiTenant/Obase.Providers.MySql/Obase.Providers.Oracle/Obase.Providers.SqlServer/Obase.Providers.Sqlite/Obase.Providers.PostgreSql
   - 无实质更新,仅更新版本号.